### PR TITLE
유저 예약과 병원 접수 테이블의 연관관계 매핑

### DIFF
--- a/src/main/java/com/project/ihealme/HptReception/controller/HptReceptionController.java
+++ b/src/main/java/com/project/ihealme/HptReception/controller/HptReceptionController.java
@@ -4,6 +4,7 @@ import com.project.ihealme.HptReception.domain.HptReception;
 import com.project.ihealme.HptReception.dto.HptRecPageRequestDTO;
 import com.project.ihealme.HptReception.service.HptReceptionService;
 import com.project.ihealme.userReservation.service.UserReservationService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -13,70 +14,68 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
+@RequiredArgsConstructor
+@RequestMapping("/HptReception")
 @Controller
 public class HptReceptionController {
 
-    @Autowired
-    private UserReservationService userReservationService;
+    private final UserReservationService userReservationService;
+    private final HptReceptionService hptReceptionService;
 
-    @Autowired
-    private HptReceptionService hptReceptionService;
-
-    @GetMapping("/HptReception/HptReceptionList")
+    @GetMapping("/HptReceptionList")
     public String hptReception(@ModelAttribute HptRecPageRequestDTO hptRecPageRequestDTO, Model model) {
-        int rtCount = hptReceptionService.getRtCount();
+//        int rtCount = hptReceptionService.getRtCount();
         Map<String, String> searchTypes = new LinkedHashMap<>();
         searchTypes.put("tx", "진료항목");
         searchTypes.put("st", "상태");
 
-        model.addAttribute("rtCount", rtCount);
+//        model.addAttribute("rtCount", rtCount);
         model.addAttribute("searchTypes", searchTypes);
         model.addAttribute("result", hptReceptionService.getUserResList(hptRecPageRequestDTO));
         return "HptReception/HptReceptionList";
     }
 
-    @PostMapping("/HptReception/HptReceptionList/addCounter")
-    @ResponseBody
-    public String addCounter() {
-        hptReceptionService.increaseRtCount();
-        return "success";
-    }
-
-    @PostMapping("/HptReception/HptReceptionList/subCounter")
-    @ResponseBody
-    public String subCounter(@RequestBody Map<String, Object> requestBody) {
-        int rtCount = (int) requestBody.get("rtCount");
-//        System.out.println("rtCount = " + rtCount);
-        if(rtCount > 0) {
-            hptReceptionService.decreaseRtCount();
-        }
-        return "success";
-    }
-
-    @GetMapping("/HptReception/HptReceptionList/updateCurrentStatusToAccept")       // <a> 태그는 get 방식으로 요청한다.
-    public String updateCurrentStatusToAccept(@RequestParam("resNo") int resNo) {
-        hptReceptionService.updateCurrentStatus(resNo, "진료 전", LocalDateTime.now());
-        userReservationService.updateCurrentStatus(resNo, "진료 전");
-        hptReceptionService.increaseRtCount(); // 대기자 수 +1
-
-        return "redirect:/HptReception/HptReceptionList";
-    }
-
-    @GetMapping("/HptReception/HptReceptionList/updateCurrentStatusToReject")
-    public String updateCurrentStatusToReject(@RequestParam("resNo") int resNo) {
-        hptReceptionService.updateCurrentStatus(resNo, "접수취소", LocalDateTime.now());
-        userReservationService.updateCurrentStatus(resNo, "접수취소");
-        return "redirect:/HptReception/HptReceptionList";
-    }
-
-    @GetMapping("/HptReception/HptReceptionList/updateCurrentStatusToComplete")
-    public String updateCurrentStatusToComplete(@RequestParam("resNo") int resNo) {
-        hptReceptionService.updateCurrentStatus(resNo, "진료완료", LocalDateTime.now());
-        userReservationService.updateCurrentStatus(resNo, "진료완료");
-        hptReceptionService.decreaseRtCount(); // 대기자 수 -1
-
-        return "redirect:/HptReception/HptReceptionList";
-    }
+//    @PostMapping("/HptReceptionList/addCounter")
+//    @ResponseBody
+//    public String addCounter() {
+//        hptReceptionService.increaseRtCount();
+//        return "success";
+//    }
+//
+//    @PostMapping("/HptReceptionList/subCounter")
+//    @ResponseBody
+//    public String subCounter(@RequestBody Map<String, Object> requestBody) {
+//        int rtCount = (int) requestBody.get("rtCount");
+////        System.out.println("rtCount = " + rtCount);
+//        if(rtCount > 0) {
+//            hptReceptionService.decreaseRtCount();
+//        }
+//        return "success";
+//    }
+//
+//    @GetMapping("/HptReceptionList/updateCurrentStatusToAccept")       // <a> 태그는 get 방식으로 요청한다.
+//    public String updateCurrentStatusToAccept(@RequestParam("resNo") int resNo) {
+//        hptReceptionService.updateCurrentStatus(resNo, "진료 전", LocalDateTime.now());
+//        userReservationService.updateCurrentStatus(resNo, "진료 전");
+//        hptReceptionService.increaseRtCount(); // 대기자 수 +1
+//
+//        return "redirect:/HptReception/HptReceptionList";
+//    }
+//
+//    @GetMapping("/HptReceptionList/updateCurrentStatusToReject")
+//    public String updateCurrentStatusToReject(@RequestParam("resNo") int resNo) {
+//        hptReceptionService.updateCurrentStatus(resNo, "접수취소", LocalDateTime.now());
+//        userReservationService.updateCurrentStatus(resNo, "접수취소");
+//        return "redirect:/HptReception/HptReceptionList";
+//    }
+//
+//    @GetMapping("/HptReceptionList/updateCurrentStatusToComplete")
+//    public String updateCurrentStatusToComplete(@RequestParam("resNo") int resNo) {
+//        hptReceptionService.updateCurrentStatus(resNo, "진료완료", LocalDateTime.now());
+//        userReservationService.updateCurrentStatus(resNo, "진료완료");
+//        hptReceptionService.decreaseRtCount(); // 대기자 수 -1
+//
+//        return "redirect:/HptReception/HptReceptionList";
+//    }
 
 }

--- a/src/main/java/com/project/ihealme/HptReception/domain/HptReception.java
+++ b/src/main/java/com/project/ihealme/HptReception/domain/HptReception.java
@@ -1,5 +1,6 @@
 package com.project.ihealme.HptReception.domain;
 
+import com.project.ihealme.userReservation.domain.UserReservation;
 import lombok.Data;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -12,29 +13,13 @@ import java.time.LocalDateTime;
 public class HptReception {
 
         @Id @Column(name = "RESNO", length = 20)
-        @GeneratedValue(strategy = GenerationType.SEQUENCE)
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "RECNO_GEN")
+        @SequenceGenerator(sequenceName = "HPTRECEPTION_NO_SEQ", name = "RECNO_GEN", allocationSize = 1)
         private int resNo;
 
-        @Column(name = "EMAIL", length = 50)
-        private String email;
+        @ManyToOne(optional = false) private UserReservation userReservation;
 
-        @Column(name = "PNAME", length = 20)
-        private String pName;
-
-        @Column(name = "TXLIST", length = 20)
-        private String txList;
-
-        @Column(name = "RDATE")
-        @ColumnDefault("sysdate")
-        private LocalDateTime rDate;
-
-        @Column(name = "CURRENTSTATUS", length = 20)
-        @ColumnDefault("'접수대기'")
-        private String currentStatus;
-
-        @Column(name = "RTCOUNT", length = 10)
-        @ColumnDefault("0")
-        private int rtCount;
+        @Column(name = "RTCOUNT", length = 10) @ColumnDefault("0") private int rtCount;
 
 }
 

--- a/src/main/java/com/project/ihealme/HptReception/repository/HptReceptionRepository.java
+++ b/src/main/java/com/project/ihealme/HptReception/repository/HptReceptionRepository.java
@@ -33,14 +33,14 @@ public interface HptReceptionRepository extends JpaRepository<HptReception, Long
      */
     // 진료상태
     @Query(value = "SELECT DISTINCT h FROM HptReception h "
-            + "WHERE h.txList like %:txList%",
+            + "WHERE h.userReservation.txList like %:txList%",
             countQuery = "select count(h) from HptReception h")
-    Page<HptReception> findByTxListContaining(@Param("txList") String txList, Pageable pageable);
+    Page<HptReception> findByUserReservation_TxListContaining(@Param("txList") String txList, Pageable pageable);
 
     // 상태
     @Query(value = "SELECT DISTINCT h FROM HptReception h "
-            + "WHERE h.currentStatus like %:currentStatus%",
+            + "WHERE h.userReservation.currentStatus like %:currentStatus%",
             countQuery = "select count(u) from UserReservation u")
-    Page<HptReception> findByCurrentStatusContaining(@Param("currentStatus") String currentStatus, Pageable pageable);
+    Page<HptReception> findByUserReservation_CurrentStatusContaining(@Param("currentStatus") String currentStatus, Pageable pageable);
 
 }

--- a/src/main/java/com/project/ihealme/HptReception/service/HptReceptionService.java
+++ b/src/main/java/com/project/ihealme/HptReception/service/HptReceptionService.java
@@ -21,10 +21,10 @@ public class HptReceptionService {
         this.hptReceptionRepository = hptReceptionRepository;
     }
 
-    @Transactional
-    public int getRtCount() {
-        return hptReceptionRepository.findRtCount();
-    }
+//    @Transactional
+//    public int getRtCount() {
+//        return hptReceptionRepository.findRtCount();
+//    }
 
     @Transactional
     public List<HptReception> getHptReceptionList() {
@@ -40,21 +40,21 @@ public class HptReceptionService {
         hptReceptionRepository.decreaseRtCount();
     }
 
-    @Transactional
-    public void updateCurrentStatus(int resNo, String newStatus, LocalDateTime rDate) {
-        // 해당 접수 번호(resNo)에 대한 HptReception 객체 가져오기
-        HptReception hptReception = hptReceptionRepository.findByResNo(resNo);
-
-        // 새로운 상태(newStatus)로 변경하기
-        hptReception.setCurrentStatus(newStatus);
-
-        // 접수 링크를 누른 시점의 sysdate 로 변경하기
-        hptReception.setRDate(rDate);
-
-        // 변경된 상태를 데이터베이스에 업데이트하기
-        hptReceptionRepository.save(hptReception);
-    }
-
+//    @Transactional
+//    public void updateCurrentStatus(int resNo, String newStatus, LocalDateTime rDate) {
+//        // 해당 접수 번호(resNo)에 대한 HptReception 객체 가져오기
+//        HptReception hptReception = hptReceptionRepository.findByResNo(resNo);
+//
+//        // 새로운 상태(newStatus)로 변경하기
+//        hptReception.setCurrentStatus(newStatus);
+//
+//        // 접수 링크를 누른 시점의 sysdate 로 변경하기
+//        hptReception.setRDate(rDate);
+//
+//        // 변경된 상태를 데이터베이스에 업데이트하기
+//        hptReceptionRepository.save(hptReception);
+//    }
+//
     public HptRecPageResponseDTO getUserResList(HptRecPageRequestDTO hptRecPageRequestDTO) {
         Page<HptReception> result = null;
 
@@ -68,10 +68,10 @@ public class HptReceptionService {
 
             switch (type) {
                 case "tx":
-                    result = hptReceptionRepository.findByTxListContaining(keyword, pageable);
+                    result = hptReceptionRepository.findByUserReservation_TxListContaining(keyword, pageable);
                     break;
                 case "st":
-                    result = hptReceptionRepository.findByCurrentStatusContaining(keyword, pageable);
+                    result = hptReceptionRepository.findByUserReservation_CurrentStatusContaining(keyword, pageable);
                     break;
             }
         }

--- a/src/main/java/com/project/ihealme/userReservation/controller/UserReservationController.java
+++ b/src/main/java/com/project/ihealme/userReservation/controller/UserReservationController.java
@@ -41,8 +41,8 @@ public class UserReservationController {
 
     @GetMapping("/userResCancelUpdate")
     public String updateCurrentStatusToComplete(@RequestParam("resNo") int resNo) {
-        userReservationService.updateCurrentStatus(resNo, "접수취소");
-        hptReceptionService.updateCurrentStatus(resNo, "접수취소", LocalDateTime.now());
+//        userReservationService.updateCurrentStatus(resNo, "접수취소");
+//        hptReceptionService.updateCurrentStatus(resNo, "접수취소", LocalDateTime.now());
         hptReceptionService.decreaseRtCount(); // 대기자 수 -1
 
         return "redirect:/userReservation";

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -2,7 +2,46 @@
 -- INSERT INTO users (user_id, answer, birth_date, business_num, email, gender, hpt_address, hpt_name, hpt_phone_num, name, password,phone_num, question, user_role) VALUES (2, 'dd', '991231', null, 'bang@naver.com', '남', null, null, null, '방기웅', '1234', '01012341234', '질문1','USER');
 -- INSERT INTO users (user_id, answer, birth_date, business_num, email, gender, hpt_address, hpt_name, hpt_phone_num, name, password,phone_num, question, user_role) VALUES (3, 'dd', '991231', null, 'sebom@hospital.co.kr', '여', null, null, null, '안유진', '1234', '01012341234', '질문1','HOSPITAL');
 
--- TODO: 데이터가 없으면 해당 페이지에 오류가 발생하므로 추후 수정작업이 필요하다.
-INSERT INTO HPTRECEPTION (RESNO, EMAIL, PNAME, TXLIST, CURRENTSTATUS) VALUES (HIBERNATE_SEQUENCE.NEXTVAL, 'sebom@hospital.co.kr', '안유진', '소아진료', '접수대기');
+-- USERRESERVATION TABLE(20)
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원1', '영유아 검진1');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원2', '영유아 검진2');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원3', '영유아 검진3');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원4', '영유아 검진4');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원5', '영유아 검진5');
 
-INSERT INTO userreservation(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원', '영유아 검진');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원6', '영유아 검진6');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원7', '영유아 검진7');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원8', '영유아 검진8');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원9', '영유아 검진9');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원10', '영유아 검진10');
+
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원11', '영유아 검진11');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원12', '영유아 검진12');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원13', '영유아 검진13');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원14', '영유아 검진14');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원15', '영유아 검진15');
+
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원16', '영유아 검진16');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원17', '영유아 검진17');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원18', '영유아 검진18');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원19', '영유아 검진19');
+INSERT INTO USERRESERVATION(RESNO, PATIENTNAME, TXLIST) VALUES (userreservation_no_seq.nextval, '새롬소아청년과의원20', '영유아 검진20');
+
+-- HPTRECEPTION TABLE(15)
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 1);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 4);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 6);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 8);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 3);
+
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 10);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 13);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 20);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 17);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 5);
+
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 14);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 19);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 2);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 7);
+INSERT INTO HPTRECEPTION(RESNO, USER_RESERVATION_RESNO) VALUES (HPTRECEPTION_NO_SEQ.nextval, 11);

--- a/src/main/resources/templates/HptReception/HptReceptionList.html
+++ b/src/main/resources/templates/HptReception/HptReceptionList.html
@@ -35,20 +35,20 @@
             <tbody>
             <tr th:each="hptReception : ${result.hptRecList}">
                 <td th:text="${hptReception.resNo}"></td>
-                <td th:text="${hptReception.pName}"></td>
-                <td th:text="${hptReception.txList}"></td>
-                <td th:text="${#temporals.format(hptReception.rDate, 'yy/MM/dd HH:mm:ss')}"></td>
-                <td th:text="${hptReception.currentStatus}"></td>
+                <td th:text="${hptReception.userReservation.patientName}"></td>
+                <td th:text="${hptReception.userReservation.txList}"></td>
+                <td th:text="${#temporals.format(hptReception.userReservation.regdate, 'yy/MM/dd HH:mm:ss')}"></td>
+                <td th:text="${hptReception.userReservation.currentStatus}"></td>
                 <td>
-                    <a th:if="${hptReception.currentStatus == '접수대기'}"
+                    <a th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
                        th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToAccept(resNo=${hptReception.resNo})}"
                        onclick="return acceptReception()">접수</a>
 
-                    <a th:if="${hptReception.currentStatus == '접수대기'}"
+                    <a th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
                        th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToReject(resNo=${hptReception.resNo})}"
                        onclick="return rejectReception()">거절</a>
 
-                    <a th:if="${hptReception.currentStatus == '진료 전'}"
+                    <a th:if="${hptReception.userReservation.currentStatus == '진료 전'}"
                        th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToComplete(resNo=${hptReception.resNo})}"
                        onclick="return completeTreatment()">진료완료</a>
                 </td>


### PR DESCRIPTION
유저 예약 테이블과 병원 접수 테이블의 연관관계를 설정하였고
이에 따른 뷰, 컨트롤러, 서비스, 리포지토리 코드를 일부 수정하였다.

.sql 파일을 통해 mock 데이터를 유저 예약 데이터-20개, 병원 접수 데이터-15개 만들었다. 이 값이 제대로 뷰에 잘 나오는지 확인작업만 했기 때문에 다른 기능(접수 상태 값 업데이트, 대기 현황 수 조정)은 올바른 기능을 위해 리팩토링 작업이 필요해서 주석처리 해놓은 상태이다.