### PR TITLE
병원 접수 2차 리팩토링 - Request 클래스 생성과 Controller, Service, Dto, 뷰 코드 수정

### DIFF
--- a/src/main/java/com/project/ihealme/HptReception/controller/HptReceptionController.java
+++ b/src/main/java/com/project/ihealme/HptReception/controller/HptReceptionController.java
@@ -1,6 +1,7 @@
 package com.project.ihealme.HptReception.controller;
 
 import com.project.ihealme.HptReception.dto.request.HptRecPageRequestDTO;
+import com.project.ihealme.HptReception.dto.request.HptReceptionRequest;
 import com.project.ihealme.HptReception.service.HptReceptionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -48,26 +49,35 @@ public class HptReceptionController {
         return "success";
     }
 
-    @GetMapping("/HptReceptionList/updateCurrentStatusToAccept")       // <a> 태그는 get 방식으로 요청한다.
-    public String updateCurrentStatusToAccept(@RequestParam("recNo") Long recNo) {
-        hptReceptionService.updateCurrentStatus(recNo, "진료 전", LocalDateTime.now());
-        hptReceptionService.increaseRtCount(); // 대기자 수 +1
+    @PostMapping("/HptReceptionList/updateCurrentStatus")       // <a> 태그는 get 방식으로 요청한다.(9/13일: <a>태그에서 <form> 태그로 수정)
+    public String updateCurrentStatusToAccept(
+        @RequestParam("recNo") Long recNo,
+        HptReceptionRequest hptReceptionRequest
+    ) {
+        hptReceptionService.updateCurrentStatus(recNo, hptReceptionRequest.toDto());
+//        hptReceptionService.increaseRtCount(); // 대기자 수 +1
 
         return "redirect:/HptReception/HptReceptionList";
     }
 
-    @GetMapping("/HptReceptionList/updateCurrentStatusToReject")
-    public String updateCurrentStatusToReject(@RequestParam("recNo") Long recNo) {
-        hptReceptionService.updateCurrentStatus(recNo, "접수취소", LocalDateTime.now());
-        return "redirect:/HptReception/HptReceptionList";
-    }
-
-    @GetMapping("/HptReceptionList/updateCurrentStatusToComplete")
-    public String updateCurrentStatusToComplete(@RequestParam("recNo") Long recNo) {
-        hptReceptionService.updateCurrentStatus(recNo, "진료완료", LocalDateTime.now());
-        hptReceptionService.decreaseRtCount(); // 대기자 수 -1
-
-        return "redirect:/HptReception/HptReceptionList";
-    }
+//    @PostMapping("/HptReceptionList/updateCurrentStatusToReject")
+//    public String updateCurrentStatusToReject(
+//        @RequestParam("recNo") Long recNo,
+//        HptReceptionRequest hptReceptionRequest
+//    ) {
+//        hptReceptionService.updateCurrentStatus(recNo, hptReceptionRequest.toDto());
+//        return "redirect:/HptReception/HptReceptionList";
+//    }
+//
+//    @PostMapping("/HptReceptionList/updateCurrentStatusToComplete")
+//    public String updateCurrentStatusToComplete(
+//        @RequestParam("recNo") Long recNo,
+//        HptReceptionRequest hptReceptionRequest
+//    ) {
+//        hptReceptionService.updateCurrentStatus(recNo, hptReceptionRequest.toDto());
+//        hptReceptionService.decreaseRtCount(); // 대기자 수 -1
+//
+//        return "redirect:/HptReception/HptReceptionList";
+//    }
 
 }

--- a/src/main/java/com/project/ihealme/HptReception/dto/HptReceptionDto.java
+++ b/src/main/java/com/project/ihealme/HptReception/dto/HptReceptionDto.java
@@ -27,7 +27,11 @@ public class HptReceptionDto {
         this.updateRegDate = updateRegDate;
     }
 
-    private HptReceptionDto of(Long recNo, String currentStatus, UserReservationDto userReservationDto, LocalDateTime regDate, LocalDateTime updateRegDate) {
+    public static HptReceptionDto of(String currentStatus) {
+        return new HptReceptionDto(null, currentStatus, null, null, null);
+    }
+
+    public static HptReceptionDto of(Long recNo, String currentStatus, UserReservationDto userReservationDto, LocalDateTime regDate, LocalDateTime updateRegDate) {
         return new HptReceptionDto(recNo, currentStatus, userReservationDto, regDate, updateRegDate);
     }
 

--- a/src/main/java/com/project/ihealme/HptReception/dto/request/HptReceptionRequest.java
+++ b/src/main/java/com/project/ihealme/HptReception/dto/request/HptReceptionRequest.java
@@ -1,0 +1,30 @@
+package com.project.ihealme.HptReception.dto.request;
+
+import com.project.ihealme.HptReception.dto.HptReceptionDto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter @Getter
+public class HptReceptionRequest {
+
+    private String currentStatus;
+
+    protected HptReceptionRequest() {
+    }
+
+    private HptReceptionRequest(String currentStatus) {
+        this.currentStatus = currentStatus;
+    }
+
+    public static HptReceptionRequest of(String currentStatus) {
+        return new HptReceptionRequest(
+            currentStatus
+        );
+    }
+
+    public HptReceptionDto toDto() {
+        return HptReceptionDto.of(
+            currentStatus
+        );
+    }
+}

--- a/src/main/java/com/project/ihealme/HptReception/service/HptReceptionService.java
+++ b/src/main/java/com/project/ihealme/HptReception/service/HptReceptionService.java
@@ -49,9 +49,20 @@ public class HptReceptionService {
     }
 
     @Transactional
-    public void updateCurrentStatus(Long recNo, String newStatus, LocalDateTime updateRegDate) {
+    public void updateCurrentStatus(Long recNo, HptReceptionDto dto) {
         HptReception hptReception = hptReceptionRepository.getReferenceById(recNo);
         UserReservation userReservation = hptReception.getUserReservation();
+        String newStatus = dto.getCurrentStatus();
+
+        if(newStatus.equals("접수")) {
+            newStatus = "진료 전";
+            hptReceptionRepository.increaseRtCount();
+        }
+        else if(newStatus.equals("진료 전")) {
+            newStatus = "진료완료";
+            hptReceptionRepository.decreaseRtCount();
+        }
+        else if(newStatus.equals("거절")) { newStatus = "접수취소"; }
 
         userReservation.setCurrentStatus(newStatus);
 

--- a/src/main/resources/static/css/HptReception/HptReception.css
+++ b/src/main/resources/static/css/HptReception/HptReception.css
@@ -102,3 +102,10 @@ form {
 .btn-secondary:hover {
     background-color: steelblue;
 }
+
+.btn-outline {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: blue;
+}

--- a/src/main/resources/static/script/HptReception/HptReception.js
+++ b/src/main/resources/static/script/HptReception/HptReception.js
@@ -92,25 +92,6 @@ function acceptReception() {
   const isAccept = confirm('접수를 수락하시겠습니까?');
 
   if (isAccept) {
-    const updateStatusPath = '/HptReception/HptReceptionList/updateCurrentStatusToAccept';
-
-    // 버튼 클릭 이벤트가 일어나면 form 요소를 동적으로 생성
-    const form = document.createElement('form');
-    form.setAttribute('method', 'post');
-    form.setAttribute('action', updateStatusPath);
-
-    // resNo 값을 전달하기 위한 hidden input 요소 추가
-    const resNoInput = document.createElement('input');
-    resNoInput.setAttribute('type', 'hidden');
-    resNoInput.setAttribute('name', 'recNo');
-    resNoInput.setAttribute('value', '${hptReception.recNo}');
-
-    // form 요소와 hidden input 요소를 body에 추가하고 submit
-    form.appendChild(resNoInput);
-    document.body.appendChild(form);
-
-    //confirm 메시지를 띄우고, 사용자가 확인을 누른 경우에만 form을 submit합니다.
-    form.submit();
     alert('접수가 수락되었습니다.');
   }
 
@@ -121,25 +102,6 @@ function rejectReception() {
   const isReject = confirm('접수를 취소하시겠습니까?');
 
   if (isReject) {
-    const updateStatusPath = '/HptReception/HptReceptionList/updateCurrentStatusToReject';
-
-    // 버튼 클릭 이벤트가 일어나면 form 요소를 동적으로 생성
-    const form = document.createElement('form');
-    form.setAttribute('method', 'post');
-    form.setAttribute('action', updateStatusPath);
-
-    // resNo 값을 전달하기 위한 hidden input 요소 추가
-    const resNoInput = document.createElement('input');
-    resNoInput.setAttribute('type', 'hidden');
-    resNoInput.setAttribute('name', 'recNo');
-    resNoInput.setAttribute('value', '${hptReception.recNo}');
-
-    // form 요소와 hidden input 요소를 body에 추가하고 submit
-    form.appendChild(resNoInput);
-    document.body.appendChild(form);
-
-    //confirm 메시지를 띄우고, 사용자가 확인을 누른 경우에만 form을 submit합니다.
-    form.submit();
     alert('접수가 취소되었습니다.');
   }
 
@@ -151,32 +113,8 @@ function completeTreatment() {
   const isComplete = confirm('진료를 완료하시겠습니까?');
 
   if (isComplete) {
-    const updateStatusPath = '/HptReception/HptReceptionList/updateCurrentStatusToComplete';
-
-    // 버튼 클릭 이벤트가 일어나면 form 요소를 동적으로 생성
-    const form = document.createElement('form');
-    form.setAttribute('method', 'post');
-    form.setAttribute('action', updateStatusPath);
-
-    // resNo 값을 전달하기 위한 hidden input 요소 추가
-    const resNoInput = document.createElement('input');
-    resNoInput.setAttribute('type', 'hidden');
-    resNoInput.setAttribute('name', 'recNo');
-    resNoInput.setAttribute('value', '${hptReception.recNo}');
-
-    // form 요소와 hidden input 요소를 body에 추가하고 submit
-    form.appendChild(resNoInput);
-    document.body.appendChild(form);
-    form.submit();
-
-    //confirm 메시지를 띄우고, 사용자가 확인을 누른 경우에만 form을 submit합니다.
-     form.submit();
      alert('진료가 완료되었습니다.');
    }
 
     return isComplete;
   }
-
-
-
-

--- a/src/main/resources/templates/HptReception/HptReceptionList.html
+++ b/src/main/resources/templates/HptReception/HptReceptionList.html
@@ -45,17 +45,26 @@
 
                 <td th:text="${hptReception.userReservation.currentStatus}"></td>
                 <td>
-                    <a th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
-                       th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToAccept(recNo=${hptReception.recNo})}"
-                       onclick="return acceptReception()">접수</a>
+                    <form th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
+                          th:action="@{/HptReception/HptReceptionList/updateCurrentStatus(recNo=${hptReception.recNo})}"
+                          method="post">
+                        <input type="hidden" name="currentStatus" th:value="접수">
+                        <button type="submit" class="btn-outline" onclick="return acceptReception()">접수</button>
+                    </form>
 
-                    <a th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
-                       th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToReject(recNo=${hptReception.recNo})}"
-                       onclick="return rejectReception()">거절</a>
+                    <form th:if="${hptReception.userReservation.currentStatus == '접수대기'}"
+                          th:action="@{/HptReception/HptReceptionList/updateCurrentStatus(recNo=${hptReception.recNo})}"
+                          method="post">
+                        <input type="hidden" name="currentStatus" th:value="거절">
+                        <button type="submit" class="btn-outline" onclick="return acceptReception()">거절</button>
+                    </form>
 
-                    <a th:if="${hptReception.userReservation.currentStatus == '진료 전'}"
-                       th:href="@{/HptReception/HptReceptionList/updateCurrentStatusToComplete(recNo=${hptReception.recNo})}"
-                       onclick="return completeTreatment()">진료완료</a>
+                    <form th:if="${hptReception.userReservation.currentStatus == '진료 전'}"
+                                 th:action="@{/HptReception/HptReceptionList/updateCurrentStatus(recNo=${hptReception.recNo})}"
+                                 method="post">
+                    <input type="hidden" name="currentStatus" th:value="${hptReception.userReservation.currentStatus}">
+                    <button type="submit" class="btn-outline" onclick="return acceptReception()">진료완료</button>
+                </form>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
Request 클래스 생성 및 사용으로 몇 가지 수정된 부분이 있다.

- **html**: '접수', '거절', '진료완료' 버튼은 <a>태그에서 <form>태그로 변경되었다.
- **css**: 위 세 개의 버튼의 모양을 <a>태그를 사용했을 때의 모양처럼 만들기 위한 코드가 추가되었다.
- **js**: <form>태그로 파라미터를 넘겨줌으로써 필요없는 코드는 삭제되었고 alert 창을 위한 코드만 남겨두었다.
- **Controller**: 위 새 개의 버튼을 모두 받기 위해 endpoint-url 의 이름을 수정하였고 더 이상 사용하지 않는 핸들러 메서드는 주석처리 하였다. 또한 Controller에서 실시간 대기자 수를 계산하는 부분을 Service에서 수행하기 위해 주석처리를 해두었다. 
- **Dto**: Request에 매핑된 데이터를 Dto로 변환하기위한 toDto() 메서드가 추가되었으며, 이를 Dto로 변환해줄 팩토리 메서드를 추가하였다.
- **Service**: 데이터를 업데이트 해주는 updateCurrentStatus() 메서드를 수정하였고, 받은 currentStatus 값에 따라 새로운 상태 값으로 변경해주기 위한 로직을 추가하였다. 그리고 그에 맞는 실시간 대기자 수를 더하고 빼는 메서드를 추가하였다. 